### PR TITLE
CSV config

### DIFF
--- a/src/app/modules/bandwidth/views/end-user/end-user-storage.component.ts
+++ b/src/app/modules/bandwidth/views/end-user/end-user-storage.component.ts
@@ -58,7 +58,7 @@ export class EndUserStorageComponent implements OnInit {
               private _errorsManager: ErrorsManagerService,
               private _reportService: ReportService,
               private _authService: AuthService,
-              _dataConfigService: EndUserDataConfig) {
+              private _dataConfigService: EndUserDataConfig) {
     this._dataConfig = _dataConfigService.getConfig();
     this._selectedMetrics = this._dataConfig.totals.preSelected;
   }
@@ -227,18 +227,6 @@ export class EndUserStorageComponent implements OnInit {
   }
 
   private prepareCsvExportHeaders(): void {
-    let headers = '';
-    this._tabsData.forEach( total => {
-      headers = headers + total.title + ',';
-    });
-    headers = headers.substr(0, headers.length - 1) + ';';
-    this._columns.forEach( col => {
-      if (col !== 'HIDDEN') {
-        headers = headers + this._translate.instant('app.bandwidth.' + col) + ',';
-      } else {
-        headers = headers + this._translate.instant('app.bandwidth.objectId') + ',';
-      }
-    });
-    this._csvExportHeaders = headers.substr(0, headers.length - 1);
+    this._csvExportHeaders = this._dataConfigService.prepareCsvExportHeaders(this._tabsData, this._columns);
   }
 }

--- a/src/app/modules/bandwidth/views/publisher-storage/publisher-storage.component.ts
+++ b/src/app/modules/bandwidth/views/publisher-storage/publisher-storage.component.ts
@@ -57,7 +57,7 @@ export class PublisherStorageComponent implements OnInit {
               private _errorsManager: ErrorsManagerService,
               private _reportService: ReportService,
               private _authService: AuthService,
-              _dataConfigService: PublisherStorageDataConfig) {
+              private _dataConfigService: PublisherStorageDataConfig) {
     this._dataConfig = _dataConfigService.getConfig();
     this._selectedMetrics = this._dataConfig.totals.preSelected;
   }
@@ -189,15 +189,7 @@ export class PublisherStorageComponent implements OnInit {
   }
 
   private prepareCsvExportHeaders(): void {
-    let headers = '';
-    this._tabsData.forEach( (total: Tab) => {
-      headers = headers + total.title + ',';
-    });
-    headers = headers.substr(0, headers.length - 1) + ';';
-    this._columns.forEach( col => {
-      headers = headers + this._translate.instant('app.bandwidth.' + col ) + ',';
-    });
-    this._csvExportHeaders = headers.substr(0, headers.length - 1);
+    this._csvExportHeaders = this._dataConfigService.prepareCsvExportHeaders(this._tabsData, this._columns);
   }
 
 }

--- a/src/app/shared/services/storage-data-base.config.ts
+++ b/src/app/shared/services/storage-data-base.config.ts
@@ -1,4 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
+import { Tab } from 'shared/components/report-tabs/report-tabs.component';
 
 export enum ReportDataSection {
   table = 'table',
@@ -36,4 +37,23 @@ export abstract class StorageDataBaseConfig {
   }
   
   public abstract getConfig(): ReportDataConfig;
+  
+  public prepareCsvExportHeaders(tabsData: Tab[], columns: string[]): string {
+    const config = this.getConfig();
+    const totalsHeaders = Object.keys(config.totals.fields);
+    const tableColumns = Object.keys(config.table.fields);
+    let headers = '';
+  
+    tabsData.forEach( (tab: Tab) => {
+      headers = `${headers}${tab.title},`;
+    });
+
+    headers = headers.substr(0, headers.length - 1) + ';';
+  
+    columns.forEach( col => {
+      headers = `${headers}${this._translate.instant(`app.bandwidth.${col}`)},`;
+    });
+    
+    return headers.substr(0, headers.length - 1);
+  }
 }


### PR DESCRIPTION
@amirch1 we cannot use keys provided in the config because headers might be dynamically displayed in the table and we want to get config csv only for a displayed data. For example in bandwidth report we show a month or a date depends on what user selected in the UI (Monthly/Daily switcher).
Basically, I just moved the function in the shared place which accessible from all reports